### PR TITLE
Create run dircetory on start

### DIFF
--- a/service-daemon
+++ b/service-daemon
@@ -2,6 +2,7 @@
 
 set -e
 start(){
+    mkdir -p $PIDDIR
     start-stop-daemon -S -b -m -p $PIDFILE -x $DAEMON -- $DAEMON_OPTS
 }
 stop(){
@@ -14,7 +15,8 @@ stop(){
 }
 # Must be a valid filename
 NAME=service-daemon
-PIDFILE=$PREFIX/var/run/$NAME.pid
+PIDDIR=$PREFIX/var/run
+PIDFILE=$PIDDIR/$NAME.pid
 #This is the command to be run, give the full pathname
 DAEMON=$PREFIX/bin/applets/runsvdir
 DAEMON_OPTS="$SVDIR"


### PR DESCRIPTION
If the run directory doesn't exist (on a brand new installation or if it
has been deleted) starting the service may fail and under certain
circumstances causes many instances of runsvdir to be started.