### PR TITLE
Fix permission denied for start-stop-daemon

### DIFF
--- a/service-daemon
+++ b/service-daemon
@@ -3,7 +3,7 @@
 set -e
 start(){
     mkdir -p $PIDDIR
-    start-stop-daemon -S -b -m -p $PIDFILE -x $DAEMON -- $DAEMON_OPTS
+    start-stop-daemon -S -b -m -p $PIDFILE -x $DAEMON -d $PREFIX -- $DAEMON_OPTS
 }
 stop(){
     start-stop-daemon -K -s 1 -o -p $PIDFILE


### PR DESCRIPTION
Since an update, service-daemon refuses to start, it seems necessary to manually
specify the working directory of start-stop-daemon to avoid permission errors.

This issue seems to be related to this one:
https://github.com/termux/termux-packages/issues/614