### PR TITLE
Fix typo in sv-enable/disable

### DIFF
--- a/sv-disable
+++ b/sv-disable
@@ -12,7 +12,7 @@ if [ -z "$1" ];then
     show_help
     exit 1
 fi
-if [ -u "$SVDIR" ];then
+if [ -z "$SVDIR" ];then
     >&2 echo "Error: SVDIR not set"
     exit 1
 fi

--- a/sv-enable
+++ b/sv-enable
@@ -12,7 +12,7 @@ if [ -z "$1" ];then
     show_help
     exit 1
 fi
-if [ -u "$SVDIR" ];then
+if [ -z "$SVDIR" ];then
     >&2 echo "Error: SVDIR not set"
     exit 1
 fi


### PR DESCRIPTION
"-u" tests for SUID bit, not really useful here. "-z" (empty) is way more useful.
If "-u" is really useful, "-z" should also be added.