### PR TITLE
allow multiple arguments

### DIFF
--- a/sv-disable
+++ b/sv-disable
@@ -3,7 +3,7 @@
 show_help(){
 
     printf 'Usage:
-    sv-disable <service-name>
+    sv-disable <service-names>
 
     Disabling a service will make it not autostart
 '
@@ -16,5 +16,8 @@ if [ -u "$SVDIR" ];then
     >&2 echo "Error: SVDIR not set"
     exit 1
 fi
-touch "$SVDIR/$1/down"
-sv down $1
+for s in "$@"; do
+    echo "disable $s"
+    touch "$SVDIR/$s/down"
+    sv down $s
+done

--- a/sv-enable
+++ b/sv-enable
@@ -3,7 +3,7 @@
 show_help(){
 
     printf 'Usage:
-    sv-enable <service-name>
+    sv-enable <service-names>
 
     Enabling a service will make it autostart
 '
@@ -16,5 +16,8 @@ if [ -u "$SVDIR" ];then
     >&2 echo "Error: SVDIR not set"
     exit 1
 fi
-rm -f "$SVDIR/$1/down"
-sv up $1
+for s in "$@"; do
+    echo "enable $s"
+    rm -f "$SVDIR/$s/down"
+    sv up $s
+done


### PR DESCRIPTION
https://github.com/john-peterson/termux-services/pull/new/args

allow multiple arguments

i had to disable all

~~~
sv-disable $(ls $SVDIR)
~~~

# add enable/disable to runit

this demonstrates that disable is necessary down is only temporary 

~~~
sv down earlyoom
sv status earlyoom
down: earlyoom: 95s, normally up
service-daemon restart
Restarting daemon: service-daemon.
sv status earlyoom
run: earlyoom: (pid 30010) 2s

sv-disable earlyoom
service-daemon restart
sv status earlyoom
down: earlyoom: 141s
~~~

# dpkg doesn't clean $SVDIR

 dpkg also needs a patch to clean this dir. runsv will be running for every folder left over by apt remove. i prefer to have every process actually doing something 
